### PR TITLE
Issues 1 & 3 alternate fix: allow explicit setting of SyncContext.

### DIFF
--- a/src/MessageBus/DSoft.Messaging/DSoft.Messaging.csproj
+++ b/src/MessageBus/DSoft.Messaging/DSoft.Messaging.csproj
@@ -11,8 +11,6 @@
     <TargetFrameworkProfile>Profile158</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <ReleaseVersion>1.3</ReleaseVersion>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/MessageBus/DSoft.Messaging/MessageBus.cs
+++ b/src/MessageBus/DSoft.Messaging/MessageBus.cs
@@ -24,8 +24,6 @@ namespace DSoft.Messaging
 
 		public MessageBus()
 		{
-			var aSyncContext = TaskScheduler.FromCurrentSynchronizationContext();
-
 		}
 
 		#endregion
@@ -69,10 +67,10 @@ namespace DSoft.Messaging
 		}
 
 		/// <summary>
-		/// Gets or sets the sync context.
+		/// Gets or sets the sync context for the UI thread.
 		/// </summary>
 		/// <value>The sync context.</value>
-		private TaskScheduler SyncContext
+		public TaskScheduler SyncContext
 		{
 			get;
 			set;
@@ -166,11 +164,7 @@ namespace DSoft.Messaging
 
 		private void Execute (Action<object,MessageBusEvent> Action, object Sender, MessageBusEvent Evnt)
 		{
-			Task.Factory.StartNew (() => {
-				Action (Sender, Evnt);
-			}, 
-				CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
-
+            Action(Sender, Evnt);
 		}
 
 		/// <summary>
@@ -287,9 +281,10 @@ namespace DSoft.Messaging
 		/// <param name="Command">Command.</param>
 		public void RunOnUiThread(Action Command)
 		{
-			var cul = Thread.CurrentThread;
+            if (SyncContext == null)
+                throw new ArgumentNullException ("SyncContext");
 
-			//update the UI
+            //update the UI
 			Task.Factory.StartNew(() =>
 			{
 				if (Command != null)


### PR DESCRIPTION
Issue #3: do not create a task for each event.
Issue #1: allow caller to initialize SyncContext for UI thread. Throw exception if SyncContext not initialized.
